### PR TITLE
Support start/stop aws dms replication tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation "software.amazon.awssdk:rds:$sdkVersion"
     implementation "software.amazon.awssdk:docdb:$sdkVersion"
     implementation "software.amazon.awssdk:ssm:$sdkVersion"
+    implementation "software.amazon.awssdk:databasemigration:$sdkVersion"
 
     // required if using WebIdentityTokenFileCredentialsProvider
     // e.g. running as k8s pod in EKS linked to IAM role via service account

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 micronautVersion=1.2.10
 kotlinVersion=1.3.61
-sdkVersion=2.10.56
+sdkVersion=2.15.15

--- a/src/main/kotlin/org/sgdan/scheduler/Data.kt
+++ b/src/main/kotlin/org/sgdan/scheduler/Data.kt
@@ -16,6 +16,7 @@ data class Resource(
         val type: String,
         val state: String,
         val isAvailable: Boolean,
-        val multiAz: Boolean = false,   // RDS only
-        val size: Int = 0,              // ASG only
-        val max: Int = 0)               // ASG only
+        val multiAz: Boolean = false,    // RDS only
+        val size: Int = 0,               // ASG only
+        val max: Int = 0,                // ASG only
+        val arn: String = "")            // Replication tasks only


### PR DESCRIPTION
Hi @sgdan ,

I have updated the scheduler code to include start, stop operations for AWS DMS replication tasks. Also with this change Scheduler can list the AWS DMS replication instances in the UI. 
One issue I'm seeing as per my research is AWS SDK still doesn't support tags for AWS DMS resources. Because of that I can't filter the scheduler enabled resources in scheduler. Therefore start/stop operations are conducted on all AWS DMS replication tasks. 
The other issue is AWS doesn't allow stopping or starting of the replication instances. Would that be ok to list them in the UI?
Please let me know what you think about these changes.

Thanks,
